### PR TITLE
Change the default dogfood branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Git octopus action
 
-This action automatically merges branches prefixed with name "dogfood/" into the "dogfood" branch or the branch specified as input.
+This action automatically merges branches prefixed with name "dogfood/" into the "dogfood-automerge" branch or the branch specified as input.
 
 ## Inputs
 
 ### `dogfood-branch`
 
-**Required** The name of the dogfood branch. Default `dogfood`.
+**Required** The name of the dogfood branch. Default `dogfood-automerge`.
 
 ## Outputs
 
@@ -20,7 +20,7 @@ The HEAD sha1 of the dogfood branch.
 
 ## Example usage
 
-uses: drautureau-sonarsource/gh-action_git-octopus
+uses: SonarSource/gh-action_git-octopus
 secrets = ["GITHUB_TOKEN"]
 with:
-  dogfood-branch: 'dogfood-on-sonarcloud'
+  dogfood-branch: 'dogfood-on-next'

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   dogfood-branch:
     description: 'The dogfood branch'
     required: true
-    default: 'dogfood'
+    default: 'dogfood-automerge'
 outputs:
   dogfood-branch:
     description: 'The dogfood branch'


### PR DESCRIPTION
Git does not accept to have `dogfood` and `dogfood/*` branches simultaneously