### PR TITLE
Update doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The HEAD sha1 of the dogfood branch.
 ## Example usage
 
 ```
-uses: SonarSource/gh-action_dogfood_merge@1
+uses: SonarSource/gh-action_dogfood_merge@v1
 env:
   GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Git octopus action
+# gh-action_dogfood_merge
 
 This action automatically merges branches prefixed with name "dogfood/" into the "dogfood-automerge" branch or the branch specified as input.
 


### PR DESCRIPTION
## Changes
Use version branch `v1` instead of tag `1` which is now outdated and replaced by `1.0.1`.

That way new projects will refer to an up to date documentation.
Furthermore this also follow the same practice that the one used in [gh-action_release](https://github.com/SonarSource/gh-action_release) (coherence)