### PR TITLE
Corrected outputs format

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,5 +21,5 @@ git octopus origin/dogfood/* origin/master
 # Push to the dogfood branch
 git diff -s --exit-code HEAD origin/$1 || git push origin +HEAD:$1
 
-echo "name=dogfood-branch::$1" >> "$GITHUB_OUTPUT"
-echo "name=sha1::$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+echo "dogfood-branch=$1" >> "$GITHUB_OUTPUT"
+echo "sha1=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The format of the outputs has changed a bit. see: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs. This PR should allow for the correct reporting of the sha and branch name. 

Currently, the outputs are empty and we do not know which sha was deployed.
