### PR TITLE
BUILD-7997: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @sonarsource/platform-eng-xp-squad
+
+.github/CODEOWNERS @sonarsource/platform-eng-xp-squad


### PR DESCRIPTION
Define an owner for the CODEOWNER itself.