### PR TITLE
BUILD-8357 Add release notes and update-v-branch workflow

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   test-action:
-    runs-on: sonar-runner-large
+    runs-on: ubuntu-24.04-large
     name: Test Merge Dogfood Branches Action
 
     steps:

--- a/.github/workflows/update-v-branch.yml
+++ b/.github/workflows/update-v-branch.yml
@@ -1,0 +1,26 @@
+name: Update v-branch
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag
+        required: true
+        type: string
+
+jobs:
+  update-v-branch:
+    name: Update v* branch to ${{ inputs.tag }}
+    runs-on: ubuntu-24.04-large
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+      - name: update v* branch
+        run: |
+          VERSION="${{ inputs.tag }}"
+          VBRANCH="v${VERSION%%.*}"
+          git checkout -B "$VBRANCH" "$VERSION"
+          git push --force origin "$VBRANCH"

--- a/README.md
+++ b/README.md
@@ -56,3 +56,18 @@ jobs:
         with:
           dogfood-branch: 'dogfood-on-peach'
 ```
+
+## Versioning
+
+This project follows Semantic Versioning for clear and consistent version numbers.
+
+If you're using Renovate, or prefer to track stable releases, reference the latest published tag. Alternatively, you can use the `v1`
+branch, which is kept in sync with the latest release tag.
+
+⚠️ Do not use the `master` branch for your projects, as it is unstable and can change at any time.
+
+### Releasing
+
+1. Create a new release on [GitHub](https://github.com/SonarSource/gh-action_dogfood_merge/releases) and follow semantic versioning conventions.
+1. After the release is created, run the [Update v-branch workflow](https://github.com/SonarSource/gh-action_dogfood_merge/actions/workflows/update-v-branch.yml).
+This workflow will automatically update the corresponding v-branch (e.x.: `v1`) to point to the new release tag.


### PR DESCRIPTION
- Add `update-v-branch` workflow
- Update README with release notes

Tested by running

```
gh workflow run 171808460 --ref feat/mm/BUILD-8357-update-v-branch -f tag=1.1.0
```
Link to job: https://github.com/SonarSource/gh-action_dogfood_merge/actions/runs/15996658634/job/45121541597