### PR TITLE
BUILD-8875: Migrate to standardized GitHub runner names

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   test-action:
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     name: Test Merge Dogfood Branches Action
 
     steps:

--- a/.github/workflows/update-v-branch.yml
+++ b/.github/workflows/update-v-branch.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   update-v-branch:
     name: Update v* branch to ${{ inputs.tag }}
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## GitHub Actions Runner Migration

This PR updates GitHub Actions workflows to use our new standardized runner naming convention.

### Changes
- Updates runner names in workflow files to new standardized format
- No functional changes to your CI/CD pipelines
- All existing functionality remains identical

### Runner Mappings
| Old Runner | New Runner |
|------------|------------|
| sonar-runner-large | github-ubuntu-latest-s |
| ubuntu-latest-large | github-ubuntu-latest-s |
| windows-latest-large | github-windows-latest-s |
| ubuntu-24.04-large | github-ubuntu-latest-s |
| sonar-runner-large-arm | github-ubuntu-24.04-arm-s |
| ubuntu-24.04-arm-large | github-ubuntu-24.04-arm-s |

### What You Need to Do
1. Review the changes in this PR
2. Merge when ready - no additional action required
3. Old runners will remain available during transition

### Additional Information
For more details about GitHub Actions runners and their specifications, see our [GitHub Actions Runner Documentation](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3694231566/GitHub+Actions+Runner+-+GitHub).

This is an automated migration. Questions? Contact the **Engineering Experience squad**.
